### PR TITLE
changed intervals to 60 in order to address the fact that evaluation_…

### DIFF
--- a/ceilometer/files/kilo/pipeline.yaml
+++ b/ceilometer/files/kilo/pipeline.yaml
@@ -8,7 +8,7 @@
 ---
 sources:
     - name: meter_source
-      interval: 600
+      interval: 60
       meters:
           - "*"
       sinks:
@@ -20,7 +20,7 @@ sources:
       sinks:
           - cpu_sink
     - name: disk_source
-      interval: 600
+      interval: 60
       meters:
           - "disk.read.bytes"
           - "disk.read.requests"
@@ -33,7 +33,7 @@ sources:
       sinks:
           - disk_sink
     - name: network_source
-      interval: 600
+      interval: 60
       meters:
           - "network.incoming.bytes"
           - "network.incoming.packets"


### PR DESCRIPTION
…interval must be set >= the the source interval in pipeline

See -- https://ask.openstack.org/en/question/58439/heat-error-you-are-not-authorized-to-complete-this-action/
